### PR TITLE
elf: Fix loading of unaligned segments

### DIFF
--- a/root/src/kernel/include/mm.h
+++ b/root/src/kernel/include/mm.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <lock.h>
 
-#define PAGE_SIZE 4096
+#define PAGE_SIZE ((uintptr_t)4096)
 
 #define PAGE_TABLE_ENTRIES 512
 #define KERNEL_PHYS_OFFSET ((size_t)0xffffffffc0000000)


### PR DESCRIPTION
* Refactor some calculations to use PAGE_SIZE instead of 0x1000.
* Use arithmetic instead of 'if's to round up.
* Zero segment memory to avoid leaking old page contents.
* Properly add the PAGE_SIZE offset to 'buf'.