### PR TITLE
elf: Do not map PHRDs separately

### DIFF
--- a/root/src/kernel/include/elf.h
+++ b/root/src/kernel/include/elf.h
@@ -8,6 +8,7 @@
 
 #define PT_LOAD     0x00000001
 #define PT_INTERP   0x00000003
+#define PT_PHDR     0x00000006
 
 #define ABI_SYSV 0x00
 #define ARCH_X86_64 0x3e

--- a/root/src/kernel/src/drivers/elf.c
+++ b/root/src/kernel/src/drivers/elf.c
@@ -5,8 +5,6 @@
 #include <mm.h>
 #include <panic.h>
 
-#define PROCESS_IMAGE_PHDR_LOCATION     ((size_t)0x0000600000000000)
-
 /* Execute an ELF file given some file data
    out_ld_path: If non-null, returns path of the dynamic linker as kalloc()ed string */
 int elf_load(int fd, struct pagemap_t *pagemap, size_t base, struct auxval_t *auxval,
@@ -45,18 +43,7 @@ int elf_load(int fd, struct pagemap_t *pagemap, size_t base, struct auxval_t *au
         return -1;
     }
 
-    /* Read phdr into address space */
-    size_t phdr_size_in_pages = (hdr.ph_num * sizeof(struct elf_phdr_t) + (PAGE_SIZE - 1))
-            / PAGE_SIZE;
-    void *phdr_phys_addr = pmm_alloc(phdr_size_in_pages);
-    void *phdr_virt_addr = phdr_phys_addr + MEM_PHYS_OFFSET;
-    kmemcpy(phdr_virt_addr, phdr, hdr.ph_num * sizeof(struct elf_phdr_t));
-    for (size_t i = 0; i < phdr_size_in_pages; i++) {
-        map_page(pagemap, (size_t)phdr_phys_addr + i * PAGE_SIZE,
-                 base + PROCESS_IMAGE_PHDR_LOCATION + i * PAGE_SIZE, 0x07);
-    }
-
-    auxval->at_phdr = base + PROCESS_IMAGE_PHDR_LOCATION;
+    auxval->at_phdr = 0;
     auxval->at_phent = sizeof(struct elf_phdr_t);
     auxval->at_phnum = hdr.ph_num;
 
@@ -85,6 +72,8 @@ int elf_load(int fd, struct pagemap_t *pagemap, size_t base, struct auxval_t *au
                 return -1;
             }
             ld_path[phdr[i].p_filesz] = 0;
+        } else if (phdr[i].p_type == PT_PHDR) {
+            auxval->at_phdr = base + phdr[i].p_vaddr;
         } else if (phdr[i].p_type != PT_LOAD)
             continue;
 


### PR DESCRIPTION
This PR removes the hardcoded PHDR mapping at 0x6000'0000'0000.

For ELF files that require a dynamic linker, LD will create a PHDR segment for us; thus, we do not have to map PHDRs to a separate address range.

For ELF files that do not require a dynamic linker, we do not care about the PHDRs at all.