### PR TITLE
task: Allow construction of tasks using ELF ABI

### DIFF
--- a/root/src/kernel/include/panic.h
+++ b/root/src/kernel/include/panic.h
@@ -4,6 +4,16 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#define STRINGIFY(x) #x
+#define EXPAND_STRINGIFY(x) STRINGIFY(x)
+
+#define PANIC_UNLESS(c) \
+    do { \
+        if(!(c)) \
+            panic("PANIC_UNLESS(" #c ") triggered in " \
+                    __FILE__ ":" EXPAND_STRINGIFY(__LINE__), 0, 0); \
+    } while(0)
+
 void panic(const char *, uint64_t, uint64_t);
 void kexcept(const char *, size_t, size_t, size_t, size_t);
 

--- a/root/src/kernel/include/task.h
+++ b/root/src/kernel/include/task.h
@@ -76,6 +76,11 @@ struct thread_t {
     uint8_t fxstate[512] __attribute__((aligned(16)));
 };
 
+#define AT_ENTRY 10
+#define AT_PHDR 20
+#define AT_PHENT 21
+#define AT_PHNUM 22
+
 struct auxval_t {
     size_t at_entry;
     size_t at_phdr;
@@ -103,7 +108,27 @@ void init_sched(void);
 
 void yield(uint64_t);
 
-tid_t task_tcreate(pid_t, void *(*)(void *), void *);
+enum tcreate_abi {
+	tcreate_fn_call,
+	tcreate_elf_exec
+};
+
+struct tcreate_fn_call_data{
+    void (*fn)(void *);
+    void *arg;
+};
+
+struct tcreate_elf_exec_data {
+    void *entry;
+    const struct auxval_t *auxval;
+};
+
+#define TCREATE_FN_CALL_DATA(fn_, arg_) \
+    &((struct tcreate_fn_call_data){.fn=fn_, .arg=arg_})
+#define TCREATE_ELF_EXEC_DATA(entry_, auxval_) \
+    &((struct tcreate_elf_exec_data){.entry=entry_, .auxval=auxval_})
+
+tid_t task_tcreate(pid_t, enum tcreate_abi, const void *);
 pid_t task_pcreate(struct pagemap_t *);
 int task_tkill(pid_t, tid_t);
 

--- a/root/src/kernel/src/interrupts/syscalls.c
+++ b/root/src/kernel/src/interrupts/syscalls.c
@@ -52,11 +52,6 @@ void *syscall_alloc_at(struct ctx_t *ctx) {
     return (void *)base_address;
 }
 
-#define AT_ENTRY 10
-#define AT_PHDR 20
-#define AT_PHENT 21
-#define AT_PHNUM 22
-
 int syscall_getauxval(struct ctx_t *ctx) {
     pid_t proc = cpu_locals[current_cpu].current_process;
 

--- a/root/src/kernel/src/lib/userspace.c
+++ b/root/src/kernel/src/lib/userspace.c
@@ -81,7 +81,8 @@ pid_t kexec(const char *filename, const char *argv[], const char *envp[]) {
     process_table[new_pid]->auxval = auxval;
 
     /* Create main thread */
-    tid_t new_thread = task_tcreate(new_pid, (void *)entry, 0);
+    tid_t new_thread = task_tcreate(new_pid, tcreate_elf_exec,
+            TCREATE_ELF_EXEC_DATA((void *)entry, &auxval));
     if (new_thread == (tid_t)(-1)) return -1;
 
     return new_pid;

--- a/root/src/kernel/src/main.c
+++ b/root/src/kernel/src/main.c
@@ -25,7 +25,9 @@
 #include <time.h>
 #include <kbd.h>
 
-void kmain_thread(void) {
+void kmain_thread(void *arg) {
+    (void)arg;
+
     /* Execute a test process */
     spinlock_acquire(&scheduler_lock);
     kexec("/bin/test", 0, 0);/*
@@ -103,7 +105,7 @@ void kmain(void) {
     init_sched();
 
     /* Start a main kernel thread which will take over when the scheduler is running */
-    task_tcreate(0, (void *)kmain_thread, 0);
+    task_tcreate(0, tcreate_fn_call, TCREATE_FN_CALL_DATA(kmain_thread, 0));
 
     /* Unlock the scheduler for the first time */
     spinlock_release(&scheduler_lock);


### PR DESCRIPTION
Changes the signature of `task_tcreate` to allow multiple ABIs. Implement the ELF ABI auxiliary vector.