### PR TITLE
elf: Some refactoring and fixes

### DIFF
--- a/root/src/kernel/include/elf.h
+++ b/root/src/kernel/include/elf.h
@@ -37,6 +37,10 @@ struct elf_hdr_t {
     uint16_t shstrndx;
 };
 
+#define PF_X 1
+#define PF_W 2
+#define PF_R 4
+
 struct elf_phdr_t {
     uint32_t p_type;
     uint32_t p_flags;

--- a/root/src/kernel/src/drivers/elf.c
+++ b/root/src/kernel/src/drivers/elf.c
@@ -96,9 +96,6 @@ int elf_load(int fd, struct pagemap_t *pagemap, size_t base, struct auxval_t *au
             map_page(pagemap, phys, virt, pf);
         }
 
-        char *buf = (char *)((size_t)addr + MEM_PHYS_OFFSET);
-        kmemset(buf, 0, page_count * PAGE_SIZE);
-
         ret = lseek(fd, phdr[i].p_offset, SEEK_SET);
         if (ret == -1) {
             kfree(phdr);
@@ -106,6 +103,9 @@ int elf_load(int fd, struct pagemap_t *pagemap, size_t base, struct auxval_t *au
             return -1;
         }
 
+        /* Segments need to be cleared to zero; however, pmm_alloc() already returns
+           zeroed pages. Thus we just need to read the file contents. */
+        char *buf = (char *)((size_t)addr + MEM_PHYS_OFFSET);
         ret = read(fd, buf + (phdr[i].p_vaddr & (PAGE_SIZE - 1)), phdr[i].p_filesz);
         if (ret == -1) {
             kfree(phdr);

--- a/root/src/kernel/src/drivers/elf.c
+++ b/root/src/kernel/src/drivers/elf.c
@@ -87,10 +87,13 @@ int elf_load(int fd, struct pagemap_t *pagemap, size_t base, struct auxval_t *au
             return -1;
         }
 
+        size_t pf = 0x05;
+        if(phdr[i].p_flags & PF_W)
+            pf |= 0x02;
         for (size_t j = 0; j < page_count; j++) {
             size_t virt = base + phdr[i].p_vaddr + (j * PAGE_SIZE);
             size_t phys = (size_t)addr + (j * PAGE_SIZE);
-            map_page(pagemap, phys, virt, 0x07);
+            map_page(pagemap, phys, virt, pf);
         }
 
         char *buf = (char *)((size_t)addr + MEM_PHYS_OFFSET);


### PR DESCRIPTION
The important fix here is the last commit: it fixes the calculation of the number of pages that are required to map a segment. Furthermore, the first commit maps ELF segments as read-only (e.g. to aid in debugging).