### PR TITLE
elf: Pass argv and environ to userspace

### DIFF
--- a/root/src/hello/hello.c
+++ b/root/src/hello/hello.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
+#include <stdlib.h>
 
-int main(void) {
+int main(int argc, char **argv) {
+    for (int i = 0; i < argc; i++)
+        printf("My %d-th argument is %s\n", i, argv[i]);
+    printf("getenv(\"FOO\") returns %s\n", getenv("FOO"));
     for (;;) {
         char prompt[256];
         fprintf(stdout, "qword> ");

--- a/root/src/kernel/include/task.h
+++ b/root/src/kernel/include/task.h
@@ -120,13 +120,15 @@ struct tcreate_fn_call_data{
 
 struct tcreate_elf_exec_data {
     void *entry;
+    const char **argv;
+    const char **envp;
     const struct auxval_t *auxval;
 };
 
 #define tcreate_fn_call_data(fn_, arg_) \
     &((struct tcreate_fn_call_data){.fn=fn_, .arg=arg_})
-#define tcreate_elf_exec_data(entry_, auxval_) \
-    &((struct tcreate_elf_exec_data){.entry=entry_, .auxval=auxval_})
+#define tcreate_elf_exec_data(entry_, argv_, envp_, auxval_) \
+    &((struct tcreate_elf_exec_data){.entry=entry_, .argv=argv_, .envp=envp_, .auxval=auxval_})
 
 tid_t task_tcreate(pid_t, enum tcreate_abi, const void *);
 pid_t task_pcreate(struct pagemap_t *);

--- a/root/src/kernel/src/lib/userspace.c
+++ b/root/src/kernel/src/lib/userspace.c
@@ -76,7 +76,7 @@ pid_t kexec(const char *filename, const char *argv[], const char *envp[],
 
     /* Create main thread */
     tid_t new_thread = task_tcreate(new_pid, tcreate_elf_exec,
-            tcreate_elf_exec_data((void *)entry, &auxval));
+            tcreate_elf_exec_data((void *)entry, argv, envp, &auxval));
     if (new_thread == (tid_t)(-1)) return -1;
 
     return new_pid;

--- a/root/src/kernel/src/main.c
+++ b/root/src/kernel/src/main.c
@@ -30,7 +30,9 @@ void kmain_thread(void *arg) {
     (void)arg;
 
     /* Execute a test process */
-    kexec("/bin/hello", 0, 0,
+    const char *args[] = {"/bin/hello", "world", NULL};
+    const char *environ[] = {"FOO=BAR", NULL};
+    kexec("/bin/hello", args, environ,
           "/dev/tty", "/dev/tty", "/dev/tty");
 
     kprint(KPRN_INFO, "kmain: End of init.");

--- a/root/src/kernel/src/task/task.c
+++ b/root/src/kernel/src/task/task.c
@@ -388,6 +388,12 @@ found_new_task_id:;
 
     /* Set up a user stack for the thread */
     if (1) {
+        /* Virtual addresses of the stack. */
+        size_t stack_guardpage = STACK_LOCATION_TOP -
+                                 (STACK_SIZE + PAGE_SIZE/*guard page*/) * (new_tid + 1);
+        size_t stack_bottom = stack_guardpage + PAGE_SIZE;
+
+        /* Allocate physical memory for the stack and initialize it. */
         char *stack_pm = pmm_alloc(STACK_SIZE / PAGE_SIZE);
         if (!stack_pm) {
             kfree(process_table[pid]->threads[new_tid]);
@@ -395,29 +401,70 @@ found_new_task_id:;
             goto err;
         }
 
-        /* Initialize the stack state according to ELF ABI */
         size_t *sbase = (size_t *)(stack_pm + STACK_SIZE + MEM_PHYS_OFFSET);
-        size_t *sp = sbase;
+        panic_unless(!((size_t)sbase & 0xF) && "Stack base must be 16-byte aligned");
+
+        size_t *sp;
         if (abi == tcreate_elf_exec) {
             const struct tcreate_elf_exec_data *data = opaque_data;
-            /* Some care needs to be taken to keep the stack 16-byte aligned;
-               especially if this code is extended. */
-            *(--sp) = 0;
+
+            /* Push all strings onto the stack. */
+            char *strp = (char *)sbase;
+            size_t nenv = 0;
+            for (char **elem = data->envp; *elem; elem++) {
+                kprint(KPRN_INFO, "Push envp %s", *elem);
+                strp -= kstrlen(*elem) + 1;
+                kstrcpy(strp, *elem);
+                nenv++;
+            }
+            size_t nargs = 0;
+            for (char **elem = data->argv; *elem; elem++) {
+                kprint(KPRN_INFO, "Push argv %s", *elem);
+                strp -= kstrlen(*elem) + 1;
+                kstrcpy(strp, *elem);
+                nargs++;
+            }
+
+            /* Align strp to 16-byte so that the following calculation becomes easier. */
+            strp -= (size_t)strp & 0xF;
+
+            /* Make sure the *final* stack pointer is 16-byte aligned.
+                - The auxv takes a multiple of 16-bytes; ignore that.
+                - There are 2 markers that each take 8-byte; ignore that, too.
+                - Then, there is argc and (nargs + nenv)-many pointers to args/environ.
+                  Those are what we *really* care about. */
+            sp = (size_t *)strp;
+            if ((nargs + nenv + 1) & 1)
+                --sp;
 
             *(--sp) = 0; *(--sp) = 0; /* Zero auxiliary vector entry */
             sp -= 2; *sp = AT_ENTRY;    *(sp + 1) = data->auxval->at_entry;
             sp -= 2; *sp = AT_PHDR;     *(sp + 1) = data->auxval->at_phdr;
             sp -= 2; *sp = AT_PHENT;    *(sp + 1) = data->auxval->at_phent;
             sp -= 2; *sp = AT_PHNUM;    *(sp + 1) = data->auxval->at_phnum;
+
+            size_t sa = (size_t)(stack_bottom + STACK_SIZE);
             *(--sp) = 0; /* Marker for end of environ */
+            sp -= nenv;
+            for (size_t i = 0; i < nenv; i++) {
+                sa -= kstrlen(data->envp[i]) + 1;
+                sp[i] = sa;
+            }
+
             *(--sp) = 0; /* Marker for end of argv */
-            *(--sp) = 0; /* argc */
+            sp -= nargs;
+            for (size_t i = 0; i < nargs; i++) {
+                sa -= kstrlen(data->argv[i]) + 1;
+                sp[i] = sa;
+            }
+            *(--sp) = nargs; /* argc */
+        }else{
+            /* Do not push anything onto the stack. */
+            sp = sbase;
         }
+        panic_unless(!((size_t)sp & 0xF) && "Stack must be 16-byte aligned on x86_64");
 
         /* Map the stack */
-        size_t stack_guardpage = STACK_LOCATION_TOP -
-                                 (STACK_SIZE + PAGE_SIZE/*guard page*/) * (new_tid + 1);
-        size_t stack_bottom = stack_guardpage + PAGE_SIZE;
         for (size_t i = 0; i < STACK_SIZE / PAGE_SIZE; i++) {
             map_page(process_table[pid]->pagemap,
                      (size_t)(stack_pm + (i * PAGE_SIZE)),


### PR DESCRIPTION
This PR implement kernel-side support for `argv` and `environ`. Upstream mlibc already contains the required patches.