### PR TITLE
dynarray: Avoid yield() in dynarray_remove()

### DIFF
--- a/root/src/kernel/lib/lock.h
+++ b/root/src/kernel/lib/lock.h
@@ -15,11 +15,13 @@ typedef volatile int64_t lock_t;
 })
 
 #define spinlock_dec(lock) ({ \
+    int nz; \
     asm volatile ( \
         "lock dec qword ptr ds:[rbx];" \
-        : \
+        : "=@ccnz" (nz) \
         : "b" (lock) \
     ); \
+    nz; \
 })
 
 #define spinlock_read(lock) ({ \


### PR DESCRIPTION
Mark dynarray elements as non-present in dynarray_remove() and kfree() them once the last reference is deleted.