### PR TITLE
Could qword OS fit on a floppy?

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ make clean && make DEBUG=qemu img && sync
 You've now built qword, a flat `qword.img` disk image has been generated.
 To run the OS in QEMU, use `make run-img`.
 To run it with KVM enabled, use `make run-img-kvm`.
+


### PR DESCRIPTION
Even today the floppies are still being used, for example - as virtual floppies inside the coreboot open source BIOS. Just imagine: your wonderful OS could be a part of someone's BIOS build! _(for coreboot supported motherboard, maybe you have or could get one - see https://www.coreboot.org/Supported_Motherboards )_

@mintsuki and @too-r  , If you already have a coreboot-supported motherboard, or a real chance to get one, - wouldn't it be cool to be able to launch your own OS straight from the BIOS chip? ;) With one simple command its possible to add any floppy to coreboot BIOS build - and then you see it as a boot entry! Multiple floppies could be added this way _(as long as you have enough space left inside the BIOS flash chip, luckily LZMA compression could be used for the stored floppies to reduce their occupied size)_